### PR TITLE
Add Lichess provider support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [0.2.0] — 2026-03-12
+
 ### Added
+- **Lichess provider** — full `ChessProvider` implementation for Lichess API
+  - `LichessTokenAuth` — token-based authentication (most endpoints are public)
+  - `LichessClient` — supports teams, Swiss + Arena tournaments, ND-JSON streaming
+  - `--provider` / `-p` global flag to select platform: `chesscom` (default) or `lichess`
 - `club attendance` command — ranks players by tournament participation %, current streak, and all-time best streak
 - `club records` command — highlights club records across all tournaments (highest score, most wins, biggest field, highest accuracy)
 - `--year` is now optional on `club leaderboard`: omitting it returns an all-time ranking across all available tournaments
 - `--verbose` / `-v` global flag — shows execution time and cache hit/miss stats after each command
-- `AGENTS.md` — quick-reference guide for AI coding assistants
 - `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, and `CHANGELOG.md` added to the repository
 
 ### Changed
 - Removed `club history` command (redundant with `club tournaments`, which is more complete)
 - Timing and cache stats footer is now hidden by default; shown only with `--verbose`
+- Configured `ruff` linter/formatter (E/F/W/I/UP/B/SIM rules) and applied first pass across codebase
 
 ### Fixed
 - Auth layer now always sends session cookies alongside the OAuth Bearer header, ensuring internal Chess.com endpoints receive both credentials
@@ -70,5 +78,6 @@ First public release.
 
 ---
 
-[Unreleased]: https://github.com/cmellojr/chessclub/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/cmellojr/chessclub/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/cmellojr/chessclub/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/cmellojr/chessclub/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8"]
+dev = ["pytest>=8", "ruff>=0.15"]
 
 [project.scripts]
 chessclub = "chessclub_cli.main:app"
@@ -34,3 +34,19 @@ where = ["src"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
+
+[tool.ruff]
+line-length = 80
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "B", "SIM"]
+ignore = [
+    "B008",   # typer.Option() in defaults — required by Typer
+    "B904",   # raise-without-from-inside-except — fix incrementally
+    "E501",   # line-too-long — enforced by ruff format instead
+    "SIM102", # collapsible-if — readability preference
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["chessclub", "chessclub_cli"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chessclub"
-version = "0.1.0"
+version = "0.2.0"
 description = "Modular library for chess platform APIs"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/chessclub/core/interfaces.py
+++ b/src/chessclub/core/interfaces.py
@@ -2,7 +2,13 @@
 
 from abc import ABC, abstractmethod
 
-from chessclub.core.models import Club, Game, Member, Tournament, TournamentResult
+from chessclub.core.models import (
+    Club,
+    Game,
+    Member,
+    Tournament,
+    TournamentResult,
+)
 
 
 class ChessProvider(ABC):

--- a/src/chessclub/core/models.py
+++ b/src/chessclub/core/models.py
@@ -2,7 +2,6 @@
 
 from dataclasses import dataclass
 
-
 # ----------------------
 # Club
 # ----------------------
@@ -165,8 +164,11 @@ class Game:
             Mean of whichever accuracy values are present, or ``None`` if
             neither player has been reviewed.
         """
-        vals = [v for v in (self.white_accuracy, self.black_accuracy)
-                if v is not None]
+        vals = [
+            v
+            for v in (self.white_accuracy, self.black_accuracy)
+            if v is not None
+        ]
         return sum(vals) / len(vals) if vals else None
 
 

--- a/src/chessclub/providers/chesscom/auth.py
+++ b/src/chessclub/providers/chesscom/auth.py
@@ -27,7 +27,11 @@ import requests
 
 from chessclub.auth.credentials import (
     load as _load_stored,
+)
+from chessclub.auth.credentials import (
     load_oauth_token as _load_oauth_token,
+)
+from chessclub.auth.credentials import (
     save_oauth_token as _save_oauth_token,
 )
 from chessclub.auth.interfaces import AuthCredentials, AuthProvider
@@ -154,6 +158,7 @@ class ChessComCookieAuth(AuthProvider):
         if os.getenv(_ENV_ACCESS_TOKEN):
             return "environment variables"
         from chessclub.auth.credentials import credentials_path
+
         return str(credentials_path())
 
 
@@ -178,9 +183,7 @@ class _CallbackHandler(http.server.BaseHTTPRequestHandler):
 
     def do_GET(self):  # noqa: N802 — method name required by http.server
         """Handle the browser redirect from Chess.com."""
-        params = urllib.parse.parse_qs(
-            urllib.parse.urlparse(self.path).query
-        )
+        params = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
         self.server.auth_code = params.get("code", [None])[0]
         self.send_response(200)
         self.send_header("Content-Type", "text/html; charset=utf-8")
@@ -299,9 +302,7 @@ class ChessComOAuth(AuthProvider):
         # Step 1 — Generate PKCE values.
         code_verifier = secrets.token_urlsafe(64)
         digest = hashlib.sha256(code_verifier.encode()).digest()
-        code_challenge = (
-            base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
-        )
+        code_challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
 
         # Step 2 — Start a loopback server on a random OS-assigned port.
         server = http.server.HTTPServer(("127.0.0.1", 0), _CallbackHandler)

--- a/src/chessclub/providers/chesscom/cache.py
+++ b/src/chessclub/providers/chesscom/cache.py
@@ -99,8 +99,7 @@ class SQLiteCache:
                 """
             )
             conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_expires "
-                "ON cache (expires_at)"
+                "CREATE INDEX IF NOT EXISTS idx_expires ON cache (expires_at)"
             )
 
     def _delete(self, key: str) -> None:
@@ -206,9 +205,7 @@ class SQLiteCache:
         try:
             now = time.time()
             with self._connect() as conn:
-                total = conn.execute(
-                    "SELECT COUNT(*) FROM cache"
-                ).fetchone()[0]
+                total = conn.execute("SELECT COUNT(*) FROM cache").fetchone()[0]
                 expired = conn.execute(
                     "SELECT COUNT(*) FROM cache WHERE expires_at <= ?",
                     (now,),

--- a/src/chessclub/providers/chesscom/client.py
+++ b/src/chessclub/providers/chesscom/client.py
@@ -1,9 +1,11 @@
 """Chess.com provider using the public and internal web APIs."""
 
+import contextlib
 import datetime
 import json
 import re
 import time
+
 import requests
 
 from chessclub.auth.interfaces import AuthProvider
@@ -52,11 +54,13 @@ class ChessComClient(ChessProvider):
                 usable.
         """
         self.session = requests.Session()
-        self.session.headers.update({
-            "User-Agent": user_agent,
-            "X-Requested-With": "XMLHttpRequest",
-            "Accept": "application/json",
-        })
+        self.session.headers.update(
+            {
+                "User-Agent": user_agent,
+                "X-Requested-With": "XMLHttpRequest",
+                "Accept": "application/json",
+            }
+        )
 
         if auth and auth.is_authenticated():
             credentials = auth.get_credentials()
@@ -295,7 +299,7 @@ class ChessComClient(ChessProvider):
             if r.status_code == 404:
                 return None  # Signal: try the next candidate URL.
             if r.status_code == 429:
-                time.sleep(2.0 ** attempt)  # 1 s → 2 s → 4 s
+                time.sleep(2.0**attempt)  # 1 s → 2 s → 4 s
                 continue
             r.raise_for_status()
             break
@@ -365,10 +369,12 @@ class ChessComClient(ChessProvider):
             )
             return [
                 self._parse_tournament_result(
-                    {"username": p.get("username", ""),
-                     "rank": pos,
-                     "score": p.get("points"),
-                     "rating": None},
+                    {
+                        "username": p.get("username", ""),
+                        "rank": pos,
+                        "score": p.get("points"),
+                        "rating": None,
+                    },
                     tournament_id,
                 )
                 for pos, p in enumerate(players_sorted, 1)
@@ -384,10 +390,12 @@ class ChessComClient(ChessProvider):
             )
             return [
                 self._parse_tournament_result(
-                    {"username": p.get("username", ""),
-                     "rank": p.get("place_finish", 0),
-                     "score": p.get("points"),
-                     "rating": None},
+                    {
+                        "username": p.get("username", ""),
+                        "rank": p.get("place_finish", 0),
+                        "score": p.get("points"),
+                        "rating": None,
+                    },
                     tournament_id,
                 )
                 for p in players_sorted
@@ -439,7 +447,11 @@ class ChessComClient(ChessProvider):
             )
         participants = {r.player.lower() for r in results}
 
-        if not participants and tournament.player_count > 0 and tournament.club_slug:
+        if (
+            not participants
+            and tournament.player_count > 0
+            and tournament.club_slug
+        ):
             # The leaderboard endpoint returned 404 (common for Swiss club
             # tournaments on Chess.com whose internal URL differs from Arena).
             # Fall back to the full club member list as the participant set.
@@ -458,11 +470,11 @@ class ChessComClient(ChessProvider):
         # so that games from the final rounds (which can complete after the
         # official end_time) are still captured.
         _END_BUFFER = 6 * 3600  # seconds
-        effective_end = max(tournament.end_date, tournament.start_date) + _END_BUFFER
-
-        months = self._months_in_range(
-            tournament.start_date, effective_end
+        effective_end = (
+            max(tournament.end_date, tournament.start_date) + _END_BUFFER
         )
+
+        months = self._months_in_range(tournament.start_date, effective_end)
         seen: set[str] = set()
         games: list[Game] = []
 
@@ -482,29 +494,15 @@ class ChessComClient(ChessProvider):
                     end_time = raw.get("end_time")
                     if end_time is None:
                         continue
-                    if not (
-                        tournament.start_date
-                        <= end_time
-                        <= effective_end
-                    ):
+                    if not (tournament.start_date <= end_time <= effective_end):
                         continue
 
-                    white = (
-                        raw.get("white", {}).get("username", "").lower()
-                    )
-                    black = (
-                        raw.get("black", {}).get("username", "").lower()
-                    )
-                    if (
-                        white not in participants
-                        or black not in participants
-                    ):
+                    white = raw.get("white", {}).get("username", "").lower()
+                    black = raw.get("black", {}).get("username", "").lower()
+                    if white not in participants or black not in participants:
                         continue
 
-                    key = (
-                        raw.get("url")
-                        or f"{white}:{black}:{end_time}"
-                    )
+                    key = raw.get("url") or f"{white}:{black}:{end_time}"
                     if key in seen:
                         continue
                     seen.add(key)
@@ -671,9 +669,7 @@ class ChessComClient(ChessProvider):
 
         params = kwargs.get("params")
         cache_key = (
-            url
-            if not params
-            else f"{url}?{json.dumps(params, sort_keys=True)}"
+            url if not params else f"{url}?{json.dumps(params, sort_keys=True)}"
         )
 
         cached = self._cache.get(cache_key)
@@ -684,19 +680,13 @@ class ChessComClient(ChessProvider):
         self.network_requests += 1
         r = self.session.get(url, **kwargs)
         if r.status_code == 200:
-            try:
+            with contextlib.suppress(ValueError, OSError):
                 self._cache.set(cache_key, r.json(), ttl)
-            except (ValueError, OSError):
-                pass
         elif r.status_code == 404:
             # Cache 404s so repeated probes (e.g. leaderboard URL
             # variants) don't hit the network every time.
-            try:
-                self._cache.set(
-                    cache_key, {"_status": 404}, ttl
-                )
-            except (ValueError, OSError):
-                pass
+            with contextlib.suppress(ValueError, OSError):
+                self._cache.set(cache_key, {"_status": 404}, ttl)
         return r
 
     @staticmethod
@@ -721,9 +711,7 @@ class ChessComClient(ChessProvider):
         )
 
     @staticmethod
-    def _months_in_range(
-        start_ts: int, end_ts: int
-    ) -> list[tuple[int, int]]:
+    def _months_in_range(start_ts: int, end_ts: int) -> list[tuple[int, int]]:
         """Return all (year, month) pairs that overlap with a timestamp range.
 
         Args:

--- a/src/chessclub/providers/lichess/__init__.py
+++ b/src/chessclub/providers/lichess/__init__.py
@@ -1,0 +1,1 @@
+"""Lichess provider package."""

--- a/src/chessclub/providers/lichess/auth.py
+++ b/src/chessclub/providers/lichess/auth.py
@@ -1,0 +1,93 @@
+"""Lichess API token authentication."""
+
+import json
+import os
+from pathlib import Path
+
+from chessclub.auth.interfaces import AuthCredentials, AuthProvider
+from chessclub.core.exceptions import AuthenticationRequiredError
+
+
+class LichessTokenAuth(AuthProvider):
+    """Authenticates against Lichess using a personal API token.
+
+    Token resolution order:
+
+    1. Constructor argument.
+    2. ``LICHESS_API_TOKEN`` environment variable.
+    3. ``~/.config/chessclub/lichess_token.json`` (mode 0o600).
+
+    A personal API token can be generated at
+    https://lichess.org/account/oauth/token.  Most Lichess endpoints are
+    public and work without any token; the token is only required for
+    private teams or write operations.
+    """
+
+    _CONFIG_FILE = Path.home() / ".config" / "chessclub" / "lichess_token.json"
+    _ENV_VAR = "LICHESS_API_TOKEN"
+
+    def __init__(self, token: str | None = None):
+        """Initialise with an optional explicit token.
+
+        Args:
+            token: Lichess personal API token.  Falls back to the
+                environment variable and config file when ``None``.
+        """
+        self._token: str | None = (
+            token
+            or os.getenv(self._ENV_VAR)
+            or self._load_from_file()
+        )
+
+    # ------------------------------------------------------------------
+    # AuthProvider interface
+    # ------------------------------------------------------------------
+
+    def get_credentials(self) -> AuthCredentials:
+        """Return Bearer token credentials.
+
+        Returns:
+            AuthCredentials with the Authorization header set.
+
+        Raises:
+            AuthenticationRequiredError: If no token is configured.
+        """
+        if not self._token:
+            raise AuthenticationRequiredError(
+                "Lichess API token not configured. "
+                "Set LICHESS_API_TOKEN or save a token with "
+                "LichessTokenAuth.save_token(token)."
+            )
+        return AuthCredentials(
+            headers={"Authorization": f"Bearer {self._token}"}
+        )
+
+    def is_authenticated(self) -> bool:
+        """Return True if a token is available.
+
+        Returns:
+            True when a token was resolved from any source.
+        """
+        return bool(self._token)
+
+    # ------------------------------------------------------------------
+    # Token persistence
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def save_token(cls, token: str) -> None:
+        """Persist a token to disk with restricted permissions.
+
+        Args:
+            token: Lichess personal API token to save.
+        """
+        cls._CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        cls._CONFIG_FILE.write_text(json.dumps({"token": token}, indent=2))
+        cls._CONFIG_FILE.chmod(0o600)
+
+    def _load_from_file(self) -> str | None:
+        try:
+            data = json.loads(self._CONFIG_FILE.read_text())
+            return data.get("token")
+        except (FileNotFoundError, json.JSONDecodeError, KeyError):
+            return None

--- a/src/chessclub/providers/lichess/auth.py
+++ b/src/chessclub/providers/lichess/auth.py
@@ -34,9 +34,7 @@ class LichessTokenAuth(AuthProvider):
                 environment variable and config file when ``None``.
         """
         self._token: str | None = (
-            token
-            or os.getenv(self._ENV_VAR)
-            or self._load_from_file()
+            token or os.getenv(self._ENV_VAR) or self._load_from_file()
         )
 
     # ------------------------------------------------------------------

--- a/src/chessclub/providers/lichess/client.py
+++ b/src/chessclub/providers/lichess/client.py
@@ -124,19 +124,38 @@ class LichessClient(ChessProvider):
     ) -> list[Member]:
         """Return team members as Member objects.
 
-        The Lichess stream includes rating and title for every user, so
-        ``with_details`` has no additional network cost.
+        The team members endpoint returns only basic data (id,
+        joinedTeamAt).  A bulk ``POST /api/users`` call enriches
+        each member with rating, title, and last-seen timestamp.
 
         Args:
             slug: Lichess team ID.
-            with_details: Accepted for interface compatibility; ignored.
+            with_details: Accepted for interface compatibility; ignored
+                because enrichment is always performed.
 
         Returns:
             List of Member objects.
         """
         url = f"{self.BASE_URL}/team/{slug}/users"
-        users = self._get_ndjson(url, _TTL_TEAM_MEMBERS)
-        return [self._map_member(u) for u in users]
+        basic_users = self._get_ndjson(url, _TTL_TEAM_MEMBERS)
+
+        # Build lookup: lowercase id → joinedTeamAt (ms)
+        join_dates: dict[str, int | None] = {}
+        ids: list[str] = []
+        for u in basic_users:
+            uid = u.get("id") or u.get("name") or ""
+            ids.append(uid)
+            join_dates[uid.lower()] = u.get("joinedTeamAt")
+
+        # Enrich with full profiles (POST /api/users, max 300 per call)
+        enriched = self._bulk_users(ids)
+
+        members: list[Member] = []
+        for uid in ids:
+            profile = enriched.get(uid.lower(), {})
+            joined_ms = join_dates.get(uid.lower())
+            members.append(self._map_member_enriched(profile, uid, joined_ms))
+        return members
 
     def get_club_tournaments(self, slug: str) -> list[Tournament]:
         """Return all tournaments organised by the team.
@@ -220,7 +239,8 @@ class LichessClient(ChessProvider):
             Deduplicated list of Game objects sorted by average accuracy
             descending.
         """
-        tournaments = self.get_club_tournaments(slug)
+        all_tournaments = self.get_club_tournaments(slug)
+        tournaments = [t for t in all_tournaments if t.status == "finished"]
         if last_n:
             tournaments = tournaments[-last_n:]
 
@@ -252,6 +272,37 @@ class LichessClient(ChessProvider):
         url = f"{self.BASE_URL}/user/{username}"
         data = self._get_json(url, _TTL_PLAYER_PROFILE)
         return data if isinstance(data, dict) else {}
+
+    # ------------------------------------------------------------------
+    # Bulk user enrichment
+    # ------------------------------------------------------------------
+
+    def _bulk_users(self, ids: list[str]) -> dict[str, dict]:
+        """Fetch full profiles for a list of usernames.
+
+        Uses ``POST /api/users`` which accepts up to 300 IDs per call.
+
+        Args:
+            ids: List of Lichess usernames.
+
+        Returns:
+            Dict mapping lowercase username to full profile dict.
+        """
+        result: dict[str, dict] = {}
+        batch_size = 300
+        for i in range(0, len(ids), batch_size):
+            batch = ids[i : i + batch_size]
+            self.network_requests += 1
+            resp = self._session.post(
+                f"{self.BASE_URL.replace('/api', '')}/api/users",
+                data=",".join(batch),
+            )
+            if resp.status_code == 200:
+                for user in resp.json():
+                    uid = user.get("id", "").lower()
+                    if uid:
+                        result[uid] = user
+        return result
 
     # ------------------------------------------------------------------
     # Tournament helpers
@@ -359,12 +410,45 @@ class LichessClient(ChessProvider):
     @staticmethod
     def _map_member(data: dict) -> Member:
         perfs = data.get("perfs", {})
+        username = (
+            data.get("username") or data.get("name") or data.get("id", "")
+        )
         return Member(
-            username=data.get("username", ""),
+            username=username,
             rating=LichessClient._best_rating(perfs),
             title=data.get("title"),
-            joined_at=None,
+            joined_at=LichessClient._ms_to_s(data.get("joinedTeamAt")),
             activity=LichessClient._activity_tier(data.get("seenAt")),
+        )
+
+    @staticmethod
+    def _map_member_enriched(
+        profile: dict, fallback_id: str, joined_ms: int | None
+    ) -> Member:
+        """Map a bulk-fetched profile to a Member, with join date fallback.
+
+        Args:
+            profile: Full profile dict from ``POST /api/users`` (may be
+                empty if the user was not found).
+            fallback_id: Username from the team members list.
+            joined_ms: ``joinedTeamAt`` timestamp in milliseconds.
+
+        Returns:
+            Member domain model.
+        """
+        perfs = profile.get("perfs", {})
+        username = (
+            profile.get("username")
+            or profile.get("name")
+            or profile.get("id")
+            or fallback_id
+        )
+        return Member(
+            username=username,
+            rating=LichessClient._best_rating(perfs),
+            title=profile.get("title"),
+            joined_at=LichessClient._ms_to_s(joined_ms),
+            activity=LichessClient._activity_tier(profile.get("seenAt")),
         )
 
     @staticmethod

--- a/src/chessclub/providers/lichess/client.py
+++ b/src/chessclub/providers/lichess/client.py
@@ -16,7 +16,7 @@ Key differences from the Chess.com provider:
 
 import json
 import time
-from datetime import datetime, timezone
+from datetime import datetime
 
 import requests
 
@@ -40,12 +40,12 @@ from chessclub.providers.chesscom.cache import SQLiteCache
 # TTL constants (seconds)
 # ------------------------------------------------------------------
 
-_TTL_TEAM_INFO = 24 * 3600          # team name/description rarely changes
-_TTL_TEAM_MEMBERS = 3600            # joins/leaves are infrequent
-_TTL_TOURNAMENT_LIST = 3600         # new tournaments appear at most weekly
-_TTL_FINISHED_TOURNAMENT = 30 * 24 * 3600   # results are immutable
-_TTL_GAME_ARCHIVE = 30 * 24 * 3600          # finished games are immutable
-_TTL_PLAYER_PROFILE = 24 * 3600     # rating/title updated at most daily
+_TTL_TEAM_INFO = 24 * 3600  # team name/description rarely changes
+_TTL_TEAM_MEMBERS = 3600  # joins/leaves are infrequent
+_TTL_TOURNAMENT_LIST = 3600  # new tournaments appear at most weekly
+_TTL_FINISHED_TOURNAMENT = 30 * 24 * 3600  # results are immutable
+_TTL_GAME_ARCHIVE = 30 * 24 * 3600  # finished games are immutable
+_TTL_PLAYER_PROFILE = 24 * 3600  # rating/title updated at most daily
 
 # ------------------------------------------------------------------
 # Rating time-control preference (most reliable → least reliable)
@@ -279,9 +279,7 @@ class LichessClient(ChessProvider):
         items = self._get_ndjson(url, _TTL_TOURNAMENT_LIST)
         return [self._map_arena_tournament(t, slug) for t in items]
 
-    def _get_swiss_results(
-        self, tournament_id: str
-    ) -> list[TournamentResult]:
+    def _get_swiss_results(self, tournament_id: str) -> list[TournamentResult]:
         url = f"{self.BASE_URL}/swiss/{tournament_id}/results"
         items = self._get_ndjson(url, _TTL_FINISHED_TOURNAMENT)
         return [
@@ -295,9 +293,7 @@ class LichessClient(ChessProvider):
             for item in items
         ]
 
-    def _get_arena_results(
-        self, tournament_id: str
-    ) -> list[TournamentResult]:
+    def _get_arena_results(self, tournament_id: str) -> list[TournamentResult]:
         url = f"{self.BASE_URL}/tournament/{tournament_id}/results"
         items = self._get_ndjson(url, _TTL_FINISHED_TOURNAMENT)
         return [
@@ -384,9 +380,7 @@ class LichessClient(ChessProvider):
             start_date=LichessClient._iso_to_s(data.get("startsAt")),
             end_date=LichessClient._iso_to_s(data.get("finishedAt")),
             player_count=data.get("nbPlayers", 0),
-            winner_username=(
-                winner_user.get("name") or winner_user.get("id")
-            ),
+            winner_username=(winner_user.get("name") or winner_user.get("id")),
             winner_score=winner.get("points") if winner else None,
             club_slug=slug,
             url=f"https://lichess.org/swiss/{tid}",
@@ -461,9 +455,7 @@ class LichessClient(ChessProvider):
     # HTTP helpers
     # ------------------------------------------------------------------
 
-    def _get_json(
-        self, url: str, ttl: int, **params
-    ) -> dict | list | None:
+    def _get_json(self, url: str, ttl: int, **params) -> dict | list | None:
         """GET a JSON endpoint with caching and rate-limit back-off.
 
         Args:
@@ -495,9 +487,7 @@ class LichessClient(ChessProvider):
         self._cache.set(key, {"_status": 200, "_body": body}, ttl)
         return body
 
-    def _get_ndjson(
-        self, url: str, ttl: int, **params
-    ) -> list[dict]:
+    def _get_ndjson(self, url: str, ttl: int, **params) -> list[dict]:
         """GET an ND-JSON endpoint with caching.
 
         Args:
@@ -546,12 +536,10 @@ class LichessClient(ChessProvider):
         """
         headers = extra_headers or {}
         for attempt in range(3):
-            resp = self._session.get(
-                url, params=params, headers=headers
-            )
+            resp = self._session.get(url, params=params, headers=headers)
             if resp.status_code != 429:
                 return resp
-            time.sleep(2 ** attempt)
+            time.sleep(2**attempt)
         return resp
 
     # ------------------------------------------------------------------
@@ -583,9 +571,7 @@ class LichessClient(ChessProvider):
     def _cache_key(url: str, params: dict) -> str:
         if not params:
             return url
-        pairs = "&".join(
-            f"{k}={v}" for k, v in sorted(params.items())
-        )
+        pairs = "&".join(f"{k}={v}" for k, v in sorted(params.items()))
         return f"{url}?{pairs}"
 
     @staticmethod

--- a/src/chessclub/providers/lichess/client.py
+++ b/src/chessclub/providers/lichess/client.py
@@ -1,0 +1,665 @@
+"""Lichess implementation of ChessProvider.
+
+Covers the public Lichess REST API (https://lichess.org/api).
+All endpoints used here are public — no authentication is required
+unless the team is private, in which case a LichessTokenAuth instance
+should be passed to the constructor.
+
+Key differences from the Chess.com provider:
+
+- Lichess calls clubs "teams"; the slug format is identical.
+- Two tournament formats exist with separate endpoints: Swiss and Arena.
+- Member lists are returned as newline-delimited JSON (ND-JSON) streams.
+- Accuracy data is available only for analysed games (not all games).
+- No numeric club ID resolution is needed — the slug is the primary key.
+"""
+
+import json
+import time
+from datetime import datetime, timezone
+
+import requests
+
+from chessclub.auth.interfaces import AuthProvider
+from chessclub.core.exceptions import ProviderError
+from chessclub.core.interfaces import ChessProvider
+from chessclub.core.models import (
+    Club,
+    Game,
+    Member,
+    Tournament,
+    TournamentResult,
+)
+
+# TODO: SQLiteCache lives in providers/chesscom/cache.py; it should be
+# extracted to providers/cache.py as shared infrastructure once a second
+# provider (this one) needs it.
+from chessclub.providers.chesscom.cache import SQLiteCache
+
+# ------------------------------------------------------------------
+# TTL constants (seconds)
+# ------------------------------------------------------------------
+
+_TTL_TEAM_INFO = 24 * 3600          # team name/description rarely changes
+_TTL_TEAM_MEMBERS = 3600            # joins/leaves are infrequent
+_TTL_TOURNAMENT_LIST = 3600         # new tournaments appear at most weekly
+_TTL_FINISHED_TOURNAMENT = 30 * 24 * 3600   # results are immutable
+_TTL_GAME_ARCHIVE = 30 * 24 * 3600          # finished games are immutable
+_TTL_PLAYER_PROFILE = 24 * 3600     # rating/title updated at most daily
+
+# ------------------------------------------------------------------
+# Rating time-control preference (most reliable → least reliable)
+# ------------------------------------------------------------------
+
+_RATING_PREFERENCE = (
+    "rapid",
+    "classical",
+    "blitz",
+    "bullet",
+    "correspondence",
+)
+
+# ------------------------------------------------------------------
+# Arena tournament status codes
+# ------------------------------------------------------------------
+
+_ARENA_STATUS: dict[int, str] = {
+    10: "created",
+    20: "started",
+    30: "finished",
+}
+
+
+class LichessClient(ChessProvider):
+    """Chess provider backed by the Lichess public API.
+
+    Args:
+        user_agent: HTTP User-Agent header sent with every request.
+        auth: Optional auth provider for private endpoints.  Most
+            operations work without authentication.
+    """
+
+    BASE_URL = "https://lichess.org/api"
+
+    def __init__(
+        self,
+        user_agent: str = "chessclub/0.1.0",
+        auth: AuthProvider | None = None,
+    ):
+        self._session = requests.Session()
+        self._session.headers.update({"User-Agent": user_agent})
+
+        if auth and auth.is_authenticated():
+            credentials = auth.get_credentials()
+            self._session.headers.update(credentials.headers)
+
+        self._cache = SQLiteCache()
+        self.cache_hits: int = 0
+        self.network_requests: int = 0
+
+    # ------------------------------------------------------------------
+    # ChessProvider interface
+    # ------------------------------------------------------------------
+
+    def get_club(self, slug: str) -> Club:
+        """Return general team information mapped to Club.
+
+        Args:
+            slug: Lichess team ID (e.g. ``"clube-campineiro-de-xadrez"``).
+
+        Returns:
+            Club domain model.
+
+        Raises:
+            ProviderError: If the team is not found or the API fails.
+        """
+        url = f"{self.BASE_URL}/team/{slug}"
+        data = self._get_json(url, _TTL_TEAM_INFO)
+        if data is None or not isinstance(data, dict):
+            raise ProviderError(f"Lichess team not found: {slug}")
+        return self._map_club(data, slug)
+
+    def get_club_members(
+        self, slug: str, with_details: bool = False
+    ) -> list[Member]:
+        """Return team members as Member objects.
+
+        The Lichess stream includes rating and title for every user, so
+        ``with_details`` has no additional network cost.
+
+        Args:
+            slug: Lichess team ID.
+            with_details: Accepted for interface compatibility; ignored.
+
+        Returns:
+            List of Member objects.
+        """
+        url = f"{self.BASE_URL}/team/{slug}/users"
+        users = self._get_ndjson(url, _TTL_TEAM_MEMBERS)
+        return [self._map_member(u) for u in users]
+
+    def get_club_tournaments(self, slug: str) -> list[Tournament]:
+        """Return all tournaments organised by the team.
+
+        Fetches both Swiss and Arena tournaments and returns them sorted
+        by start date ascending (oldest first), matching the Chess.com
+        provider behaviour.
+
+        Args:
+            slug: Lichess team ID.
+
+        Returns:
+            List of Tournament objects, oldest first.
+        """
+        swiss = self._get_swiss_tournaments(slug)
+        arena = self._get_arena_tournaments(slug)
+        combined = swiss + arena
+        combined.sort(key=lambda t: t.start_date or 0)
+        return combined
+
+    def get_tournament_results(
+        self,
+        tournament_id: str,
+        tournament_type: str = "arena",
+        tournament_url: str | None = None,
+    ) -> list[TournamentResult]:
+        """Return per-player standings for a tournament.
+
+        Args:
+            tournament_id: Lichess tournament ID.
+            tournament_type: ``"swiss"`` or ``"arena"``.
+            tournament_url: Unused; endpoint is derived from type + ID.
+
+        Returns:
+            List of TournamentResult objects ordered by position.
+        """
+        if tournament_type == "swiss":
+            return self._get_swiss_results(tournament_id)
+        return self._get_arena_results(tournament_id)
+
+    def get_tournament_games(
+        self,
+        tournament: Tournament,
+        results: list[TournamentResult] | None = None,
+    ) -> list[Game]:
+        """Return all games played in a tournament.
+
+        Accuracy data is included when available (requires prior game
+        analysis on Lichess; many games will have ``None``).
+
+        Args:
+            tournament: Tournament domain model.
+            results: Unused; Lichess returns all games via a direct
+                tournament games endpoint without needing a player list.
+
+        Returns:
+            List of Game objects sorted by average accuracy descending;
+            games without accuracy data appear last.
+        """
+        if tournament.tournament_type == "swiss":
+            games = self._get_swiss_games(tournament)
+        else:
+            games = self._get_arena_games(tournament)
+        return sorted(
+            games,
+            key=lambda g: g.avg_accuracy if g.avg_accuracy is not None else -1,
+            reverse=True,
+        )
+
+    def get_club_games(
+        self, slug: str, last_n: int | None = None
+    ) -> list[Game]:
+        """Return games from recent club tournaments.
+
+        Args:
+            slug: Lichess team ID.
+            last_n: Number of most recent tournaments to scan.  ``None``
+                scans all tournaments.
+
+        Returns:
+            Deduplicated list of Game objects sorted by average accuracy
+            descending.
+        """
+        tournaments = self.get_club_tournaments(slug)
+        if last_n:
+            tournaments = tournaments[-last_n:]
+
+        games: list[Game] = []
+        seen: set[tuple] = set()
+
+        for tournament in tournaments:
+            for game in self.get_tournament_games(tournament):
+                key = (game.white, game.black, game.played_at)
+                if key not in seen:
+                    seen.add(key)
+                    games.append(game)
+
+        return sorted(
+            games,
+            key=lambda g: g.avg_accuracy if g.avg_accuracy is not None else -1,
+            reverse=True,
+        )
+
+    def get_player(self, username: str) -> dict:
+        """Return raw player profile data from Lichess.
+
+        Args:
+            username: Lichess username.
+
+        Returns:
+            Raw API response dict.
+        """
+        url = f"{self.BASE_URL}/user/{username}"
+        data = self._get_json(url, _TTL_PLAYER_PROFILE)
+        return data if isinstance(data, dict) else {}
+
+    # ------------------------------------------------------------------
+    # Tournament helpers
+    # ------------------------------------------------------------------
+
+    def _get_swiss_tournaments(self, slug: str) -> list[Tournament]:
+        """Fetch Swiss tournaments for the team.
+
+        The endpoint returns ND-JSON (one object per line).
+
+        Returns:
+            List of Tournament objects with tournament_type ``"swiss"``.
+        """
+        url = f"{self.BASE_URL}/team/{slug}/swiss"
+        items = self._get_ndjson(url, _TTL_TOURNAMENT_LIST)
+        return [self._map_swiss_tournament(t, slug) for t in items]
+
+    def _get_arena_tournaments(self, slug: str) -> list[Tournament]:
+        """Fetch Arena tournaments for the team.
+
+        Returns:
+            List of Tournament objects with tournament_type ``"arena"``.
+        """
+        url = f"{self.BASE_URL}/team/{slug}/arena"
+        items = self._get_ndjson(url, _TTL_TOURNAMENT_LIST)
+        return [self._map_arena_tournament(t, slug) for t in items]
+
+    def _get_swiss_results(
+        self, tournament_id: str
+    ) -> list[TournamentResult]:
+        url = f"{self.BASE_URL}/swiss/{tournament_id}/results"
+        items = self._get_ndjson(url, _TTL_FINISHED_TOURNAMENT)
+        return [
+            TournamentResult(
+                tournament_id=tournament_id,
+                player=item.get("username", ""),
+                position=item.get("rank", 0),
+                score=item.get("points"),
+                rating=item.get("rating"),
+            )
+            for item in items
+        ]
+
+    def _get_arena_results(
+        self, tournament_id: str
+    ) -> list[TournamentResult]:
+        url = f"{self.BASE_URL}/tournament/{tournament_id}/results"
+        items = self._get_ndjson(url, _TTL_FINISHED_TOURNAMENT)
+        return [
+            TournamentResult(
+                tournament_id=tournament_id,
+                player=item.get("username", ""),
+                position=item.get("rank", 0),
+                score=item.get("score"),
+                rating=item.get("rating"),
+            )
+            for item in items
+        ]
+
+    def _get_swiss_games(self, tournament: Tournament) -> list[Game]:
+        url = f"{self.BASE_URL}/swiss/{tournament.id}/games"
+        items = self._get_ndjson(
+            url,
+            _TTL_GAME_ARCHIVE,
+            moves="false",
+            accuracy="true",
+            opening="true",
+        )
+        return [
+            g
+            for item in items
+            if (g := self._map_game(item, tournament.id)) is not None
+        ]
+
+    def _get_arena_games(self, tournament: Tournament) -> list[Game]:
+        url = f"{self.BASE_URL}/tournament/{tournament.id}/games"
+        items = self._get_ndjson(
+            url,
+            _TTL_GAME_ARCHIVE,
+            moves="false",
+            accuracy="true",
+            opening="true",
+        )
+        return [
+            g
+            for item in items
+            if (g := self._map_game(item, tournament.id)) is not None
+        ]
+
+    # ------------------------------------------------------------------
+    # Domain model mappers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _map_club(data: dict, slug: str) -> Club:
+        return Club(
+            id=slug,
+            provider_id=None,
+            name=data.get("name", slug),
+            description=data.get("description"),
+            country=None,
+            url=f"https://lichess.org/team/{slug}",
+            members_count=data.get("nbMembers"),
+            created_at=LichessClient._ms_to_s(data.get("createdAt")),
+            location=data.get("location"),
+            matches_count=None,
+        )
+
+    @staticmethod
+    def _map_member(data: dict) -> Member:
+        perfs = data.get("perfs", {})
+        return Member(
+            username=data.get("username", ""),
+            rating=LichessClient._best_rating(perfs),
+            title=data.get("title"),
+            joined_at=None,
+            activity=LichessClient._activity_tier(data.get("seenAt")),
+        )
+
+    @staticmethod
+    def _map_swiss_tournament(data: dict, slug: str) -> Tournament:
+        winner = data.get("winner", {})
+        winner_user = winner.get("user", {}) if winner else {}
+        tid = data.get("id", "")
+        return Tournament(
+            id=tid,
+            name=data.get("name", ""),
+            tournament_type="swiss",
+            status=data.get("status", "finished"),
+            start_date=LichessClient._iso_to_s(data.get("startsAt")),
+            end_date=LichessClient._iso_to_s(data.get("finishedAt")),
+            player_count=data.get("nbPlayers", 0),
+            winner_username=(
+                winner_user.get("name") or winner_user.get("id")
+            ),
+            winner_score=winner.get("points") if winner else None,
+            club_slug=slug,
+            url=f"https://lichess.org/swiss/{tid}",
+        )
+
+    @staticmethod
+    def _map_arena_tournament(data: dict, slug: str) -> Tournament:
+        status_code = data.get("status", 30)
+        winner = data.get("winner", {})
+        tid = data.get("id", "")
+        return Tournament(
+            id=tid,
+            name=data.get("fullName", data.get("name", "")),
+            tournament_type="arena",
+            status=_ARENA_STATUS.get(
+                status_code if isinstance(status_code, int) else 30,
+                "finished",
+            ),
+            start_date=LichessClient._ms_to_s(data.get("startsAt")),
+            end_date=LichessClient._ms_to_s(data.get("finishesAt")),
+            player_count=data.get("nbPlayers", 0),
+            winner_username=(
+                winner.get("name") or winner.get("id") if winner else None
+            ),
+            winner_score=None,
+            club_slug=slug,
+            url=f"https://lichess.org/tournament/{tid}",
+        )
+
+    @staticmethod
+    def _map_game(data: dict, tournament_id: str) -> Game | None:
+        """Map a Lichess game object to the Game domain model.
+
+        Args:
+            data: Raw game dict from the Lichess NDJSON export.
+            tournament_id: ID of the parent tournament.
+
+        Returns:
+            Game instance, or ``None`` for aborted games.
+        """
+        if data.get("status") == "aborted":
+            return None
+
+        players = data.get("players", {})
+        white_data = players.get("white", {})
+        black_data = players.get("black", {})
+        white_user = white_data.get("user", {})
+        black_user = black_data.get("user", {})
+
+        white_name = white_user.get("name") or white_user.get("id", "?")
+        black_name = black_user.get("name") or black_user.get("id", "?")
+
+        opening = data.get("opening", {})
+        gid = data.get("id", "")
+
+        return Game(
+            white=white_name,
+            black=black_name,
+            result=LichessClient._game_result(
+                data.get("winner"), data.get("status", "")
+            ),
+            opening_eco=opening.get("eco") if opening else None,
+            pgn=None,
+            played_at=LichessClient._ms_to_s(data.get("createdAt")),
+            white_accuracy=white_data.get("accuracy"),
+            black_accuracy=black_data.get("accuracy"),
+            tournament_id=tournament_id,
+            url=f"https://lichess.org/{gid}",
+        )
+
+    # ------------------------------------------------------------------
+    # HTTP helpers
+    # ------------------------------------------------------------------
+
+    def _get_json(
+        self, url: str, ttl: int, **params
+    ) -> dict | list | None:
+        """GET a JSON endpoint with caching and rate-limit back-off.
+
+        Args:
+            url: Full endpoint URL.
+            ttl: Cache TTL in seconds.
+            **params: Query string parameters.
+
+        Returns:
+            Parsed JSON (dict or list) or ``None`` on error/404.
+        """
+        key = self._cache_key(url, params)
+        cached = self._cache.get(key)
+        if cached is not None:
+            self.cache_hits += 1
+            if cached.get("_status") == 404:
+                return None
+            return cached.get("_body")
+
+        self.network_requests += 1
+        resp = self._fetch(url, params=params or None)
+
+        if resp.status_code == 404:
+            self._cache.set(key, {"_status": 404, "_body": None}, ttl)
+            return None
+        if resp.status_code != 200:
+            return None
+
+        body = resp.json()
+        self._cache.set(key, {"_status": 200, "_body": body}, ttl)
+        return body
+
+    def _get_ndjson(
+        self, url: str, ttl: int, **params
+    ) -> list[dict]:
+        """GET an ND-JSON endpoint with caching.
+
+        Args:
+            url: Full endpoint URL.
+            ttl: Cache TTL in seconds.
+            **params: Query string parameters.
+
+        Returns:
+            List of parsed JSON objects, empty on error.
+        """
+        key = self._cache_key(url, params)
+        cached = self._cache.get(key)
+        if cached is not None:
+            self.cache_hits += 1
+            return cached.get("_items", [])
+
+        self.network_requests += 1
+        resp = self._fetch(
+            url,
+            params=params or None,
+            extra_headers={"Accept": "application/x-ndjson"},
+        )
+
+        if resp.status_code != 200:
+            return []
+
+        items = self._parse_ndjson(resp.text)
+        self._cache.set(key, {"_items": items}, ttl)
+        return items
+
+    def _fetch(
+        self,
+        url: str,
+        params: dict | None = None,
+        extra_headers: dict | None = None,
+    ) -> requests.Response:
+        """Execute GET with exponential back-off on HTTP 429.
+
+        Args:
+            url: Endpoint URL.
+            params: Query string parameters.
+            extra_headers: Additional headers to merge for this request.
+
+        Returns:
+            The HTTP response.
+        """
+        headers = extra_headers or {}
+        for attempt in range(3):
+            resp = self._session.get(
+                url, params=params, headers=headers
+            )
+            if resp.status_code != 429:
+                return resp
+            time.sleep(2 ** attempt)
+        return resp
+
+    # ------------------------------------------------------------------
+    # Static helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _parse_ndjson(text: str) -> list[dict]:
+        """Parse a newline-delimited JSON response body.
+
+        Args:
+            text: Raw response text.
+
+        Returns:
+            List of parsed dicts; malformed lines are silently skipped.
+        """
+        items = []
+        for line in text.strip().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                items.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+        return items
+
+    @staticmethod
+    def _cache_key(url: str, params: dict) -> str:
+        if not params:
+            return url
+        pairs = "&".join(
+            f"{k}={v}" for k, v in sorted(params.items())
+        )
+        return f"{url}?{pairs}"
+
+    @staticmethod
+    def _ms_to_s(ms: int | None) -> int | None:
+        """Convert millisecond timestamp to seconds (Arena format)."""
+        return ms // 1000 if ms is not None else None
+
+    @staticmethod
+    def _iso_to_s(iso: str | None) -> int | None:
+        """Convert ISO 8601 string to Unix timestamp (Swiss format).
+
+        Args:
+            iso: Timestamp string such as ``"2026-03-29T22:30:00Z"``.
+
+        Returns:
+            Unix timestamp in seconds, or ``None`` on parse failure.
+        """
+        if not iso:
+            return None
+        try:
+            dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+            return int(dt.timestamp())
+        except (ValueError, AttributeError):
+            return None
+
+    @staticmethod
+    def _best_rating(perfs: dict) -> int | None:
+        """Return the best available rating from a Lichess perfs dict.
+
+        Args:
+            perfs: The ``perfs`` field from a Lichess user object.
+
+        Returns:
+            Rating int, or ``None`` if no rated games exist.
+        """
+        for tc in _RATING_PREFERENCE:
+            perf = perfs.get(tc, {})
+            if perf.get("games", 0) > 0:
+                return perf.get("rating")
+        return None
+
+    @staticmethod
+    def _activity_tier(seen_at_ms: int | None) -> str | None:
+        """Map a ``seenAt`` timestamp to an activity tier string.
+
+        Args:
+            seen_at_ms: Unix timestamp in milliseconds, or ``None``.
+
+        Returns:
+            ``"weekly"``, ``"monthly"``, ``"all_time"``, or ``None``.
+        """
+        if seen_at_ms is None:
+            return None
+        elapsed_days = (time.time() - seen_at_ms / 1000) / 86400
+        if elapsed_days <= 7:
+            return "weekly"
+        if elapsed_days <= 30:
+            return "monthly"
+        return "all_time"
+
+    @staticmethod
+    def _game_result(winner: str | None, status: str) -> str:
+        """Map Lichess winner/status to a PGN result string.
+
+        Args:
+            winner: ``"white"``, ``"black"``, or ``None`` for draws.
+            status: Lichess game termination status (unused but kept
+                for potential future use with stalemate/insufficient).
+
+        Returns:
+            ``"1-0"``, ``"0-1"``, or ``"1/2-1/2"``.
+        """
+        if winner == "white":
+            return "1-0"
+        if winner == "black":
+            return "0-1"
+        return "1/2-1/2"

--- a/src/chessclub/services/attendance_service.py
+++ b/src/chessclub/services/attendance_service.py
@@ -90,14 +90,16 @@ class AttendanceService:
                 else:
                     streak = 0
 
-            records.append(AttendanceRecord(
-                username=player,
-                tournaments_played=played,
-                total_tournaments=total,
-                participation_pct=round(pct, 1),
-                current_streak=current,
-                max_streak=max_streak,
-            ))
+            records.append(
+                AttendanceRecord(
+                    username=player,
+                    tournaments_played=played,
+                    total_tournaments=total,
+                    participation_pct=round(pct, 1),
+                    current_streak=current,
+                    max_streak=max_streak,
+                )
+            )
 
         records.sort(
             key=lambda r: (r.participation_pct, r.max_streak),

--- a/src/chessclub/services/club_service.py
+++ b/src/chessclub/services/club_service.py
@@ -1,7 +1,13 @@
 """Service layer that wraps a ChessProvider for club-related operations."""
 
 from chessclub.core.interfaces import ChessProvider
-from chessclub.core.models import Club, Game, Member, Tournament, TournamentResult
+from chessclub.core.models import (
+    Club,
+    Game,
+    Member,
+    Tournament,
+    TournamentResult,
+)
 
 
 class ClubService:
@@ -137,9 +143,7 @@ class ClubService:
             A list of :class:`Game` instances ordered best-to-worst by
             average Stockfish accuracy.
         """
-        return self.provider.get_tournament_games(
-            tournament, results=results
-        )
+        return self.provider.get_tournament_games(tournament, results=results)
 
     def get_club_games(
         self, slug: str, last_n: int | None = None

--- a/src/chessclub/services/leaderboard_service.py
+++ b/src/chessclub/services/leaderboard_service.py
@@ -96,13 +96,15 @@ class LeaderboardService:
         result: list[PlayerStats] = []
         for s in stats.values():
             played = s["tournaments_played"]
-            result.append(PlayerStats(
-                username=s["username"],
-                tournaments_played=played,
-                wins=s["wins"],
-                total_score=s["total_score"],
-                avg_score=s["total_score"] / played if played else 0.0,
-            ))
+            result.append(
+                PlayerStats(
+                    username=s["username"],
+                    tournaments_played=played,
+                    wins=s["wins"],
+                    total_score=s["total_score"],
+                    avg_score=s["total_score"] / played if played else 0.0,
+                )
+            )
 
         result.sort(key=lambda p: (p.total_score, p.wins), reverse=True)
         return result

--- a/src/chessclub/services/matchup_service.py
+++ b/src/chessclub/services/matchup_service.py
@@ -45,9 +45,7 @@ class MatchupService:
             first).  Ties are broken alphabetically by
             ``player_a``.
         """
-        games = self.provider.get_club_games(
-            slug, last_n=last_n
-        )
+        games = self.provider.get_club_games(slug, last_n=last_n)
 
         pairs: dict[tuple[str, str], dict] = {}
 
@@ -100,20 +98,18 @@ class MatchupService:
 
         result: list[Matchup] = []
         for entry in pairs.values():
-            total = (
-                entry["wins_a"]
-                + entry["wins_b"]
-                + entry["draws"]
+            total = entry["wins_a"] + entry["wins_b"] + entry["draws"]
+            result.append(
+                Matchup(
+                    player_a=entry["player_a"],
+                    player_b=entry["player_b"],
+                    wins_a=entry["wins_a"],
+                    wins_b=entry["wins_b"],
+                    draws=entry["draws"],
+                    total_games=total,
+                    last_played=entry["last_played"],
+                )
             )
-            result.append(Matchup(
-                player_a=entry["player_a"],
-                player_b=entry["player_b"],
-                wins_a=entry["wins_a"],
-                wins_b=entry["wins_b"],
-                draws=entry["draws"],
-                total_games=total,
-                last_played=entry["last_played"],
-            ))
 
         result.sort(
             key=lambda m: (

--- a/src/chessclub/services/rating_history_service.py
+++ b/src/chessclub/services/rating_history_service.py
@@ -49,7 +49,7 @@ class RatingHistoryService:
         tournaments = self.provider.get_club_tournaments(slug)
 
         tournaments.sort(
-            key=lambda t: (t.end_date or t.start_date or 0),
+            key=lambda t: t.end_date or t.start_date or 0,
         )
 
         if last_n is not None:
@@ -67,15 +67,17 @@ class RatingHistoryService:
             for r in results:
                 if r.player.lower() != target:
                     continue
-                snapshots.append(RatingSnapshot(
-                    tournament_id=t.id,
-                    tournament_name=t.name,
-                    tournament_type=t.tournament_type,
-                    tournament_date=t.end_date or t.start_date,
-                    rating=r.rating,
-                    position=r.position,
-                    score=r.score,
-                ))
+                snapshots.append(
+                    RatingSnapshot(
+                        tournament_id=t.id,
+                        tournament_name=t.name,
+                        tournament_type=t.tournament_type,
+                        tournament_date=t.end_date or t.start_date,
+                        rating=r.rating,
+                        position=r.position,
+                        score=r.score,
+                    )
+                )
                 break
 
         return snapshots

--- a/src/chessclub/services/records_service.py
+++ b/src/chessclub/services/records_service.py
@@ -1,7 +1,5 @@
 """Service for computing club records and highlights."""
 
-import datetime
-
 from chessclub.core.interfaces import ChessProvider
 from chessclub.core.models import ClubRecord
 
@@ -88,41 +86,49 @@ class RecordsService:
 
         # Highest single-tournament score.
         if best_score:
-            records.append(ClubRecord(
-                category="Highest tournament score",
-                value=f"{best_score[0]:.1f} pts",
-                player=best_score[1],
-                detail=best_score[2],
-                date=best_score[3],
-            ))
+            records.append(
+                ClubRecord(
+                    category="Highest tournament score",
+                    value=f"{best_score[0]:.1f} pts",
+                    player=best_score[1],
+                    detail=best_score[2],
+                    date=best_score[3],
+                )
+            )
 
         # Most tournaments played.
         if most_played:
             top = max(most_played.items(), key=lambda x: x[1])
-            records.append(ClubRecord(
-                category="Most tournaments played",
-                value=str(top[1]),
-                player=top[0],
-            ))
+            records.append(
+                ClubRecord(
+                    category="Most tournaments played",
+                    value=str(top[1]),
+                    player=top[0],
+                )
+            )
 
         # Most 1st-place finishes.
         if most_wins:
             top = max(most_wins.items(), key=lambda x: x[1])
-            records.append(ClubRecord(
-                category="Most 1st-place finishes",
-                value=str(top[1]),
-                player=top[0],
-            ))
+            records.append(
+                ClubRecord(
+                    category="Most 1st-place finishes",
+                    value=str(top[1]),
+                    player=top[0],
+                )
+            )
 
         # Biggest tournament.
         if biggest_tournament:
-            records.append(ClubRecord(
-                category="Biggest tournament",
-                value=f"{biggest_tournament[0]} players",
-                player=None,
-                detail=biggest_tournament[1],
-                date=biggest_tournament[2],
-            ))
+            records.append(
+                ClubRecord(
+                    category="Biggest tournament",
+                    value=f"{biggest_tournament[0]} players",
+                    player=None,
+                    detail=biggest_tournament[1],
+                    date=biggest_tournament[2],
+                )
+            )
 
         return records
 
@@ -139,8 +145,10 @@ class RecordsService:
             games = self.provider.get_tournament_games(t)
             for g in games:
                 if g.avg_accuracy is not None:
-                    if (best_accuracy is None
-                            or g.avg_accuracy > best_accuracy[0]):
+                    if (
+                        best_accuracy is None
+                        or g.avg_accuracy > best_accuracy[0]
+                    ):
                         best_accuracy = (
                             g.avg_accuracy,
                             g.white,
@@ -157,32 +165,37 @@ class RecordsService:
                     (g.black_accuracy, g.black, g.white),
                 ]:
                     if acc is not None:
-                        if (best_player_acc is None
-                                or acc > best_player_acc[0]):
+                        if best_player_acc is None or acc > best_player_acc[0]:
                             best_player_acc = (
-                                acc, player, opponent,
-                                g.url, g.played_at,
+                                acc,
+                                player,
+                                opponent,
+                                g.url,
+                                g.played_at,
                             )
 
         if best_accuracy:
-            records.append(ClubRecord(
-                category="Highest avg accuracy (game)",
-                value=f"{best_accuracy[0]:.1f}%",
-                player=f"{best_accuracy[1]} vs {best_accuracy[2]}",
-                detail=(
-                    f"{best_accuracy[3]:.1f}% / "
-                    f"{best_accuracy[4]:.1f}%"
-                ),
-                date=best_accuracy[6],
-            ))
+            records.append(
+                ClubRecord(
+                    category="Highest avg accuracy (game)",
+                    value=f"{best_accuracy[0]:.1f}%",
+                    player=f"{best_accuracy[1]} vs {best_accuracy[2]}",
+                    detail=(
+                        f"{best_accuracy[3]:.1f}% / {best_accuracy[4]:.1f}%"
+                    ),
+                    date=best_accuracy[6],
+                )
+            )
 
         if best_player_acc:
-            records.append(ClubRecord(
-                category="Highest individual accuracy",
-                value=f"{best_player_acc[0]:.1f}%",
-                player=best_player_acc[1],
-                detail=f"vs {best_player_acc[2]}",
-                date=best_player_acc[4],
-            ))
+            records.append(
+                ClubRecord(
+                    category="Highest individual accuracy",
+                    value=f"{best_player_acc[0]:.1f}%",
+                    player=best_player_acc[1],
+                    detail=f"vs {best_player_acc[2]}",
+                    date=best_player_acc[4],
+                )
+            )
 
         return records

--- a/src/chessclub_cli/main.py
+++ b/src/chessclub_cli/main.py
@@ -91,7 +91,7 @@ app.add_typer(player_app, name="player")
 
 console = Console(legacy_windows=False)
 
-_USER_AGENT = "Chessclub/0.1 (contact: cmellojr@gmail.com)"
+_USER_AGENT = "Chessclub/0.2 (contact: cmellojr@gmail.com)"
 _VALIDATION_CLUB = "chess-com-developer-community"
 _ENV_CLIENT_ID = "CHESSCOM_CLIENT_ID"
 
@@ -943,6 +943,9 @@ def games(
             f"[dim]Fetching games ({scope})…[/dim]", spinner="dots"
         ):
             data = service.get_club_games(slug, last_n=n)
+            # Build tournament ID → name map for display (cached, no cost)
+            tournaments = service.get_club_tournaments(slug)
+            tid_to_name = {t.id: t.name for t in tournaments}
     except AuthenticationRequiredError as e:
         console.print(f"[red]Error:[/red] {e}", highlight=False)
         raise typer.Exit(1)
@@ -989,7 +992,7 @@ def games(
 
     else:
         table = Table(title=f"Tournament Games — {slug}", show_lines=False)
-        table.add_column("Tournament", style="dim", no_wrap=False)
+        table.add_column("Tournament", style="dim", no_wrap=True, max_width=20)
         table.add_column("White", style="cyan")
         table.add_column("W%", justify="right")
         table.add_column("Black", style="cyan")
@@ -999,8 +1002,11 @@ def games(
         table.add_column("Date", justify="right")
 
         for g in data:
+            t_label = tid_to_name.get(
+                g.tournament_id or "", g.tournament_id or "—"
+            )
             table.add_row(
-                g.tournament_id or "—",
+                t_label,
                 g.white,
                 _fmt_acc(g.white_accuracy),
                 g.black,

--- a/src/chessclub_cli/main.py
+++ b/src/chessclub_cli/main.py
@@ -39,6 +39,21 @@ from chessclub.providers.chesscom.auth import ChessComCookieAuth, ChessComOAuth
 from chessclub.providers.chesscom.client import ChessComClient
 from chessclub.services.club_service import ClubService
 
+class Provider(str, Enum):
+    """Supported chess platforms."""
+
+    chesscom = "chesscom"
+    lichess = "lichess"
+
+
+class OutputFormat(str, Enum):
+    """Supported output formats for club commands."""
+
+    table = "table"
+    json = "json"
+    csv = "csv"
+
+
 app = typer.Typer()
 club_app = typer.Typer()
 auth_app = typer.Typer(help="Manage Chess.com authentication.")
@@ -54,10 +69,17 @@ def _main_callback(
         "-v",
         help="Show timing, cache/network stats, and auth method.",
     ),
+    provider: Provider = typer.Option(
+        Provider.chesscom,
+        "--provider",
+        "-p",
+        help="Platform to use: chesscom (default) or lichess.",
+    ),
 ) -> None:
     """Chessclub — CLI for chess platform analytics."""
-    global _verbose
+    global _verbose, _provider_name
     _verbose = verbose
+    _provider_name = provider.value
 
 app.add_typer(club_app, name="club")
 app.add_typer(auth_app, name="auth")
@@ -72,19 +94,7 @@ _ENV_CLIENT_ID = "CHESSCOM_CLIENT_ID"
 
 _current_provider: ChessComClient | None = None
 _verbose: bool = False
-
-
-# ---------------------------------------------------------------------------
-# Output format
-# ---------------------------------------------------------------------------
-
-
-class OutputFormat(str, Enum):
-    """Supported output formats for club commands."""
-
-    table = "table"
-    json = "json"
-    csv = "csv"
+_provider_name: str = "chesscom"
 
 
 # ---------------------------------------------------------------------------
@@ -108,14 +118,19 @@ def _print_footer(elapsed: float) -> None:
         elif hits and net:
             parts.append(f"{hits} cache / {net} network")
         # Auth method summary.
-        has_cookie = bool(_current_provider.session.cookies)
-        has_oauth = "Authorization" in _current_provider.session.headers
-        if has_cookie and has_oauth:
-            parts.append("auth: cookie + OAuth")
-        elif has_cookie:
-            parts.append("auth: cookie")
-        elif has_oauth:
-            parts.append("auth: OAuth")
+        if _provider_name == "lichess":
+            sess = getattr(_current_provider, "_session", None)
+            if sess and "Authorization" in sess.headers:
+                parts.append("auth: token")
+        else:
+            has_cookie = bool(_current_provider.session.cookies)
+            has_oauth = "Authorization" in _current_provider.session.headers
+            if has_cookie and has_oauth:
+                parts.append("auth: cookie + OAuth")
+            elif has_cookie:
+                parts.append("auth: cookie")
+            elif has_oauth:
+                parts.append("auth: OAuth")
     console.print(f"\n[dim]{' · '.join(parts)}[/dim]")
 
 
@@ -156,15 +171,24 @@ def _resolve_client_id() -> str:
 
 
 def _get_service() -> ClubService:
-    """Build and return a ClubService backed by the Chess.com provider.
+    """Build and return a ClubService backed by the selected provider.
 
-    Prefers OAuth 2.0 when a client ID is available and an OAuth token
-    file exists; falls back to :class:`ChessComCookieAuth` otherwise.
+    When ``--provider lichess`` is active, returns a ClubService backed
+    by :class:`~chessclub.providers.lichess.client.LichessClient`.
+    Otherwise defaults to Chess.com, preferring OAuth 2.0 when a client
+    ID is available; falls back to :class:`ChessComCookieAuth`.
 
     Returns:
         A :class:`~chessclub.services.club_service.ClubService` instance.
     """
     global _current_provider
+    if _provider_name == "lichess":
+        from chessclub.providers.lichess.auth import LichessTokenAuth
+        from chessclub.providers.lichess.client import LichessClient
+        auth = LichessTokenAuth()
+        provider = LichessClient(user_agent=_USER_AGENT, auth=auth)
+        _current_provider = provider
+        return ClubService(provider)
     client_id = _resolve_client_id()
     use_oauth = client_id and creds_store.load_oauth_token()
     cookie_auth = ChessComCookieAuth()

--- a/src/chessclub_cli/main.py
+++ b/src/chessclub_cli/main.py
@@ -6,6 +6,7 @@ ChessComCookieAuth, ChessComOAuth).  All other layers depend solely on
 abstractions.
 """
 
+import contextlib
 import csv
 import functools
 import io
@@ -38,6 +39,7 @@ from chessclub.core.exceptions import AuthenticationRequiredError
 from chessclub.providers.chesscom.auth import ChessComCookieAuth, ChessComOAuth
 from chessclub.providers.chesscom.client import ChessComClient
 from chessclub.services.club_service import ClubService
+
 
 class Provider(str, Enum):
     """Supported chess platforms."""
@@ -80,6 +82,7 @@ def _main_callback(
     global _verbose, _provider_name
     _verbose = verbose
     _provider_name = provider.value
+
 
 app.add_typer(club_app, name="club")
 app.add_typer(auth_app, name="auth")
@@ -136,6 +139,7 @@ def _print_footer(elapsed: float) -> None:
 
 def _timed(func):
     """Decorator that prints elapsed time and cache stats after a command."""
+
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         global _current_provider
@@ -146,6 +150,7 @@ def _timed(func):
         finally:
             elapsed = time.perf_counter() - t0
             _print_footer(elapsed)
+
     return wrapper
 
 
@@ -185,6 +190,7 @@ def _get_service() -> ClubService:
     if _provider_name == "lichess":
         from chessclub.providers.lichess.auth import LichessTokenAuth
         from chessclub.providers.lichess.client import LichessClient
+
         auth = LichessTokenAuth()
         provider = LichessClient(user_agent=_USER_AGENT, auth=auth)
         _current_provider = provider
@@ -242,9 +248,7 @@ def _to_csv(rows: list[dict], fieldnames: list[str]) -> str:
         A CSV-formatted string including a header row.
     """
     buf = io.StringIO()
-    writer = csv.DictWriter(
-        buf, fieldnames=fieldnames, extrasaction="ignore"
-    )
+    writer = csv.DictWriter(buf, fieldnames=fieldnames, extrasaction="ignore")
     writer.writeheader()
     writer.writerows(rows)
     return buf.getvalue()
@@ -312,12 +316,9 @@ def login():
     """Authenticate via OAuth 2.0 PKCE (requires Chess.com developer access)."""
     client_id = _resolve_client_id()
     if not client_id:
+        console.print("[red]No client_id found.[/red]\n")
         console.print(
-            "[red]No client_id found.[/red]\n"
-        )
-        console.print(
-            "Each user must obtain their own client_id "
-            "from Chess.com:\n"
+            "Each user must obtain their own client_id from Chess.com:\n"
         )
         console.print(
             "  1. Join the Chess.com Developer Community\n"
@@ -397,17 +398,13 @@ def status():
             )
         else:
             console.print("[red]✗ OAuth token expired or invalid.[/red]")
-            console.print(
-                "Run [bold]chessclub auth login[/bold] to renew."
-            )
+            console.print("Run [bold]chessclub auth login[/bold] to renew.")
             raise typer.Exit(1)
     else:
         # Cookie session — validate against an authenticated endpoint.
         console.print("[dim]Validating with Chess.com...[/dim]")
         try:
-            client = ChessComClient(
-                user_agent=_USER_AGENT, auth=cookie_auth
-            )
+            client = ChessComClient(user_agent=_USER_AGENT, auth=cookie_auth)
             club = client.get_club(_VALIDATION_CLUB)
             if club.provider_id:
                 r = client.session.get(
@@ -421,13 +418,9 @@ def status():
                         "Session cookies are expired or invalid."
                     )
                 r.raise_for_status()
-            console.print(
-                "[green]✓ Active credentials are valid.[/green]"
-            )
+            console.print("[green]✓ Active credentials are valid.[/green]")
         except AuthenticationRequiredError:
-            console.print(
-                "[red]✗ Credentials expired or invalid.[/red]"
-            )
+            console.print("[red]✗ Credentials expired or invalid.[/red]")
             console.print(
                 "Run [bold]chessclub auth login[/bold] or "
                 "[bold]chessclub auth setup[/bold] to renew."
@@ -468,10 +461,8 @@ def stats(
 
     # Tournament count requires auth; omit silently if unavailable.
     tournaments_count: int | None = None
-    try:
+    with contextlib.suppress(AuthenticationRequiredError, Exception):
         tournaments_count = len(service.get_club_tournaments(slug))
-    except (AuthenticationRequiredError, Exception):
-        pass
 
     club.matches_count = tournaments_count
 
@@ -504,9 +495,7 @@ def stats(
             code = country_url.rstrip("/").split("/")[-1].upper()
             if len(code) != 2 or not code.isalpha():
                 return ""
-            return "".join(
-                chr(0x1F1E0 + ord(c) - ord("A")) for c in code
-            )
+            return "".join(chr(0x1F1E0 + ord(c) - ord("A")) for c in code)
 
         # Strip HTML tags; convert <br> to newline first
         def _strip_html(html: str | None) -> str:
@@ -614,7 +603,9 @@ def members(
         table.add_column("Joined", justify="right")
 
         for m in data:
-            activity_label = _ACTIVITY_LABEL.get(m.activity or "", m.activity or "—")
+            activity_label = _ACTIVITY_LABEL.get(
+                m.activity or "", m.activity or "—"
+            )
             activity_style = _ACTIVITY_STYLE.get(m.activity or "", "")
             styled_activity = (
                 f"[{activity_style}]{activity_label}[/{activity_style}]"
@@ -734,8 +725,15 @@ def tournaments(
 
         elif output == OutputFormat.csv:
             _gfields = [
-                "white", "black", "result", "opening_eco", "played_at",
-                "white_accuracy", "black_accuracy", "avg_accuracy", "url",
+                "white",
+                "black",
+                "result",
+                "opening_eco",
+                "played_at",
+                "white_accuracy",
+                "black_accuracy",
+                "avg_accuracy",
+                "url",
             ]
             rows = []
             for g in game_data:
@@ -769,7 +767,9 @@ def tournaments(
                 )
 
             console.print(gtable)
-            using_member_fallback = participant_count == 0 and len(game_data) > 0
+            using_member_fallback = (
+                participant_count == 0 and len(game_data) > 0
+            )
             participants_label = (
                 "club members (leaderboard unavailable)"
                 if using_member_fallback
@@ -803,7 +803,7 @@ def tournaments(
     if output == OutputFormat.json:
         rows = [asdict(t) for t in data]
         if details:
-            for row, t in zip(rows, data):
+            for row, t in zip(rows, data, strict=True):
                 try:
                     results = service.get_tournament_results(
                         t.id,
@@ -825,9 +825,15 @@ def tournaments(
                 "--output csv. Showing summary only."
             )
         _fields = [
-            "id", "name", "tournament_type", "status",
-            "start_date", "end_date", "player_count",
-            "winner_username", "winner_score",
+            "id",
+            "name",
+            "tournament_type",
+            "status",
+            "start_date",
+            "end_date",
+            "player_count",
+            "winner_username",
+            "winner_score",
         ]
         print(_to_csv([asdict(t) for t in data], _fields), end="")
 
@@ -943,7 +949,8 @@ def games(
 
     if min_accuracy > 0:
         data = [
-            g for g in data
+            g
+            for g in data
             if g.avg_accuracy is not None and g.avg_accuracy >= min_accuracy
         ]
 
@@ -981,9 +988,7 @@ def games(
         print(_to_csv(rows, _fields), end="")
 
     else:
-        table = Table(
-            title=f"Tournament Games — {slug}", show_lines=False
-        )
+        table = Table(title=f"Tournament Games — {slug}", show_lines=False)
         table.add_column("Tournament", style="dim", no_wrap=False)
         table.add_column("White", style="cyan")
         table.add_column("W%", justify="right")
@@ -1011,9 +1016,7 @@ def games(
             f"({with_accuracy} with accuracy data)[/]"
         )
         if not data:
-            scope_hint = (
-                f"last {last_n}" if n else "all"
-            )
+            scope_hint = f"last {last_n}" if n else "all"
             console.print(
                 f"[yellow]Tip:[/yellow] No games were found in the {scope_hint} "
                 "tournament(s). The leaderboard endpoint may not be available "
@@ -1098,8 +1101,11 @@ def leaderboard(
 
     elif output == OutputFormat.csv:
         _fields = [
-            "username", "tournaments_played", "wins",
-            "total_score", "avg_score",
+            "username",
+            "tournaments_played",
+            "wins",
+            "total_score",
+            "avg_score",
         ]
         print(_to_csv([asdict(p) for p in data], _fields), end="")
 
@@ -1126,9 +1132,7 @@ def leaderboard(
             )
 
         console.print(table)
-        console.print(
-            f"[dim]{len(data)} players · {period_label}[/dim]"
-        )
+        console.print(f"[dim]{len(data)} players · {period_label}[/dim]")
 
 
 # ---------------------------------------------------------------------------
@@ -1183,9 +1187,7 @@ def matchups(
         raise typer.Exit(1)
 
     if not data:
-        console.print(
-            "[yellow]No matchup data found.[/yellow]"
-        )
+        console.print("[yellow]No matchup data found.[/yellow]")
         raise typer.Exit(0)
 
     if output == OutputFormat.json:
@@ -1193,8 +1195,13 @@ def matchups(
 
     elif output == OutputFormat.csv:
         _fields = [
-            "player_a", "player_b", "wins_a", "wins_b",
-            "draws", "total_games", "last_played",
+            "player_a",
+            "player_b",
+            "wins_a",
+            "wins_b",
+            "draws",
+            "total_games",
+            "last_played",
         ]
         print(_to_csv([asdict(m) for m in data], _fields), end="")
 
@@ -1221,10 +1228,7 @@ def matchups(
             )
 
         console.print(table)
-        console.print(
-            f"[dim]{len(data)} matchups · "
-            f"{scope} tournaments[/dim]"
-        )
+        console.print(f"[dim]{len(data)} matchups · {scope} tournaments[/dim]")
 
 
 # ---------------------------------------------------------------------------
@@ -1240,8 +1244,7 @@ def attendance(
         0,
         "--last-n",
         help=(
-            "Only consider the N most recent tournaments. "
-            "0 = all tournaments."
+            "Only consider the N most recent tournaments. 0 = all tournaments."
         ),
     ),
     output: OutputFormat = typer.Option(
@@ -1285,8 +1288,12 @@ def attendance(
 
     elif output == OutputFormat.csv:
         _fields = [
-            "username", "tournaments_played", "total_tournaments",
-            "participation_pct", "current_streak", "max_streak",
+            "username",
+            "tournaments_played",
+            "total_tournaments",
+            "participation_pct",
+            "current_streak",
+            "max_streak",
         ]
         print(_to_csv([asdict(a) for a in data], _fields), end="")
 
@@ -1314,11 +1321,7 @@ def attendance(
             )
 
         console.print(table)
-        console.print(
-            f"[dim]{len(data)} players · "
-            f"{scope} tournaments[/dim]"
-        )
-
+        console.print(f"[dim]{len(data)} players · {scope} tournaments[/dim]")
 
 
 # ---------------------------------------------------------------------------
@@ -1364,8 +1367,7 @@ def records(
         n: int | None = last_n if last_n > 0 else None
         scope = f"last {last_n}" if n else "all"
         with console.status(
-            f"[dim]Fetching records ({scope} tournaments "
-            f"for games)…[/dim]",
+            f"[dim]Fetching records ({scope} tournaments for games)…[/dim]",
             spinner="dots",
         ):
             data = rs.get_records(slug, last_n=n)
@@ -1382,9 +1384,7 @@ def records(
 
     elif output == OutputFormat.csv:
         _fields = ["category", "value", "player", "detail", "date"]
-        print(
-            _to_csv([asdict(r) for r in data], _fields), end=""
-        )
+        print(_to_csv([asdict(r) for r in data], _fields), end="")
 
     else:
         table = Table(
@@ -1407,9 +1407,7 @@ def records(
             )
 
         console.print(table)
-        console.print(
-            f"[dim]{len(data)} records[/dim]"
-        )
+        console.print(f"[dim]{len(data)} records[/dim]")
 
 
 # ---------------------------------------------------------------------------
@@ -1464,9 +1462,7 @@ def rating_history(
             f"({scope} tournaments)…[/dim]",
             spinner="dots",
         ):
-            data = rhs.get_rating_history(
-                club, username, last_n=last_n
-            )
+            data = rhs.get_rating_history(club, username, last_n=last_n)
     except AuthenticationRequiredError as e:
         console.print(f"[red]Error:[/red] {e}", highlight=False)
         raise typer.Exit(1)
@@ -1483,9 +1479,13 @@ def rating_history(
 
     elif output == OutputFormat.csv:
         _fields = [
-            "tournament_id", "tournament_name",
-            "tournament_type", "tournament_date",
-            "rating", "position", "score",
+            "tournament_id",
+            "tournament_name",
+            "tournament_type",
+            "tournament_date",
+            "rating",
+            "position",
+            "score",
         ]
         print(_to_csv([asdict(s) for s in data], _fields), end="")
 
@@ -1514,9 +1514,7 @@ def rating_history(
             )
 
         console.print(table)
-        console.print(
-            f"[dim]{len(data)} tournaments · {username}[/dim]"
-        )
+        console.print(f"[dim]{len(data)} tournaments · {username}[/dim]")
 
 
 # ---------------------------------------------------------------------------
@@ -1537,8 +1535,7 @@ def cache_stats() -> None:
         raise typer.Exit(1)
     n = s["total"]
     console.print(
-        f"Entries : {n} total  "
-        f"({s['active']} active, {s['expired']} expired)"
+        f"Entries : {n} total  ({s['active']} active, {s['expired']} expired)"
     )
     console.print(f"Location: {SQLiteCache._DB_PATH}")
     console.print(f"Size    : {s['size_bytes'] / 1024:.1f} KB")


### PR DESCRIPTION
## Summary
- Full `ChessProvider` implementation for Lichess API (`LichessTokenAuth` + `LichessClient`)
- Supports Swiss + Arena tournaments, ND-JSON streaming, bulk user enrichment
- `--provider` / `-p` global flag to select platform: `chesscom` (default) or `lichess`
- Configured `ruff` linter/formatter and applied first pass across codebase
- Version bumped to 0.2.0

## Changes
- **New**: `src/chessclub/providers/lichess/` — auth, client, and package init
- **Modified**: `src/chessclub_cli/main.py` — `Provider` enum, `--provider` flag, Lichess branch in `_get_service()`, tournament name in games table
- **Modified**: `pyproject.toml` — version 0.2.0, ruff config, ruff dev dependency
- **Modified**: `CHANGELOG.md` — v0.2.0 release notes
- **Modified**: All source files — ruff formatting + lint fixes

## Test plan
- [x] `chessclub -p lichess club stats clube-campineiro-de-xadrez`
- [x] `chessclub -p lichess club members clube-campineiro-de-xadrez --details`
- [x] `chessclub -p lichess club tournaments clube-campineiro-de-xadrez`
- [x] `chessclub -p lichess club games clube-campineiro-de-xadrez --last-n 3`
- [x] `chessclub club stats clube-de-xadrez-de-jundiai` (Chess.com unchanged)
- [x] `ruff check src/` and `ruff format --check src/` pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)